### PR TITLE
feat: valibotへの変換でtransformに対応

### DIFF
--- a/src/model/model-to-valibot.ts
+++ b/src/model/model-to-valibot.ts
@@ -252,8 +252,15 @@ export namespace ModelToValibot {
     let fromStr = ''
     try {
       fromStr = Visit(TypeToSchema(typeof schema[Types.TransformKind].Decode(1)))
-    } catch (_) {
-      fromStr = 'v.any()'
+    } catch (e) {
+      console.warn(
+        '[ModelToValibot] An error occurred while executing the Decode function with argument 1, so it was converted to "any"',
+        {
+          Decode: schema[Types.TransformKind].Decode.toString(),
+          error: e
+        }
+      )
+      fromStr = 'v.any(/* failed to convert from Decode function */)'
     }
 
     // transformの処理内容はEncodeをそのまま流用する

--- a/test/model/index.ts
+++ b/test/model/index.ts
@@ -1,2 +1,3 @@
 import './indexer'
 import './types'
+import './valibot'

--- a/test/model/valibot.ts
+++ b/test/model/valibot.ts
@@ -128,3 +128,28 @@ export const Test = v.object({
   Assert.IsEqual(code, expect)
 })
 
+test('ModelToValibot:Transform Error Object to Array', () => {
+  const TestSchema = Types.Transform(Types.Array(Types.String(), { $id: 'Test' }))
+    .Decode((v) => {
+      return v.reduce((object, key) => {
+        object[key] = true
+        return object
+      }, {} as Record<string, boolean>)
+    })
+    .Encode((v) => Object.keys(v))
+
+  const code = ModelToValibot.Generate({
+    types: [TestSchema],
+  })
+  const expect =
+`import * as v from 'valibot'
+
+export type Test = v.InferOutput<typeof Test>
+export const Test = v.pipe(
+  v.any(/* failed to convert from Decode function */),
+  v.transform((v) => Object.keys(v)),
+  v.array(v.string())
+)
+`
+  Assert.IsEqual(code, expect)
+})

--- a/test/model/valibot.ts
+++ b/test/model/valibot.ts
@@ -1,0 +1,130 @@
+import { ModelToValibot } from '@sinclair/typebox-codegen'
+import * as Types from '@sinclair/typebox'
+import { Assert } from '../assert'
+import { test } from 'node:test'
+
+test('ModelToValibot:String', () => {
+  const code = ModelToValibot.Generate({
+    types: [Types.String({ $id: 'Test' })],
+  })
+  const expect =
+`import * as v from 'valibot'
+
+export type Test = v.InferOutput<typeof Test>
+export const Test = v.string()
+`
+  Assert.IsEqual(code, expect)
+})
+
+test('ModelToValibot:Transform String to Number', () => {
+  const TestSchema = Types.Transform(Types.Number({ minimum: 1, maximum: 50, $id: 'Test' }))
+    .Decode((value) => String(value))
+    .Encode((value) => Number(value))
+  const code = ModelToValibot.Generate({
+    types: [TestSchema],
+  })
+  const expect =
+`import * as v from 'valibot'
+
+export type Test = v.InferOutput<typeof Test>
+export const Test = v.pipe(
+  v.string(),
+  v.transform((value) => Number(value)),
+  v.number(),
+  v.minValue(1),
+  v.maxValue(50)
+)
+`
+  Assert.IsEqual(code, expect)
+})
+
+test('ModelToValibot:Transform String to Boolean', () => {
+  const TestSchema = Types.Transform(Types.Boolean({$id: 'Test' }))
+    .Decode((value) => String(value))
+    .Encode((value) => value === 'true')
+  const code = ModelToValibot.Generate({
+    types: [TestSchema],
+  })
+  const expect =
+`import * as v from 'valibot'
+
+export type Test = v.InferOutput<typeof Test>
+export const Test = v.pipe(
+  v.string(),
+  v.transform((value) => value === 'true'),
+  v.boolean()
+)
+`
+  Assert.IsEqual(code, expect)
+})
+
+test('ModelToValibot:Transform Object to Array', () => {
+  const TestSchema = Types.Transform(Types.Array(Types.String(), { $id: 'Test' }))
+    .Decode((v) => {
+      if (!Array.isArray(v)) {
+        return {}
+      }
+      return v.reduce((object, key) => {
+        object[key] = true
+        return object
+      }, {} as Record<string, boolean>)
+    })
+    .Encode((v) => Object.keys(v))
+
+  const code = ModelToValibot.Generate({
+    types: [TestSchema],
+  })
+  const expect =
+`import * as v from 'valibot'
+
+export type Test = v.InferOutput<typeof Test>
+export const Test = v.pipe(
+  v.object({}),
+  v.transform((v) => Object.keys(v)),
+  v.array(v.string())
+)
+`
+  Assert.IsEqual(code, expect)
+})
+
+test('ModelToValibot:Transform Object', () => {
+  const PageSchema = Types.Transform(Types.Number({ minimum: 1, $id: 'Page' }))
+    .Decode((v) => String(v))
+    .Encode((v) => Number(v))
+  const TestSchema = Types.Object(
+    {
+      Page: PageSchema,
+      OptionalPage: Types.Optional(PageSchema),
+    },
+    {
+      $id: 'Test',
+    },
+  )
+
+  const code = ModelToValibot.Generate({
+    types: [TestSchema],
+  })
+  const expect =
+`import * as v from 'valibot'
+
+export type Test = v.InferOutput<typeof Test>
+export const Test = v.object({
+  Page: v.pipe(
+    v.string(),
+    v.transform((v) => Number(v)),
+    v.number(),
+    v.minValue(1)
+  ),
+  OptionalPage: v.optional(
+    v.pipe(
+      v.string(),
+      v.transform((v) => Number(v)),
+      v.number(),
+      v.minValue(1)
+    )
+  )
+})
+`
+  Assert.IsEqual(code, expect)
+})
+


### PR DESCRIPTION
## 変更の経緯

- openapiのドキュメントや共通的に使用する型はtypeboxから生成しているが、TypeboxのTransformが変換できない為クエリパラメータ用のvalibotは直書きしている。
- それによってopenapiのドキュメントとクエリパラメータの定義に差分が発生している。（最小値や最大値のずれ）
- 人為的なミスを減らす為にもtypeboxで一元管理をしたいが、その為にはTypeboxのTransformをv.transformに変換できる必要がある。

## 変更内容

- `ModelToValibot`にTransformの場合の処理を追加

## テスト方法

- `npm run test`

```
okabe@OBook-Pro typebox-codegen % npm run test

> @sinclair/typebox-codegen@0.11.1 test
> hammer task test

[task]: test 
[build]: /Users/okabe/Documents/project/workflow/types/typebox-codegen/test/index.ts
Done: 240ms
✔ Indexer:StringKey (27.430709ms)
✔ Indexer:NumberKey (4.412166ms)
✔ Model:Any (3.669417ms)
✔ Model:Array (2.062583ms)
✔ Model:BigInt (5.003125ms)
✔ Model:Boolean (1.340916ms)
✔ Model:Date (1.642584ms)
✔ Model:Uint8Array (1.415791ms)
✔ Model:String (1.703125ms)
✔ Model:Number (1.281042ms)
✔ Model:Symbol (1.969458ms)
✔ Model:Null (0.960584ms)
✔ Model:Never (0.967125ms)
✔ Model:Undefined (1.014458ms)
✔ Model:Void (1.009666ms)
✔ Model:Tuple (3.2ms)
✔ Model:Object (1.428ms)
✔ Model:Record (1.248958ms)
✔ Model:Unknown (0.965959ms)
✔ Model:Promise (0.989333ms)
✔ Model:Intersect 1 (1.287333ms)
✔ Model:Intersect 2 (1.465041ms)
✔ Model:Union 1 (1.185584ms)
✔ Model:Union 2 (1.439083ms)
✔ Model:Literal 1 (1.088667ms)
✔ Model:Literal 2 (1.394458ms)
✔ Model:Literal 3 (0.873834ms)
✔ Model:TemplateLiteral 1 (1.598875ms)
✔ Model:TemplateLiteral 2 (2.032792ms)
✔ Model:Function (1.485ms)
✔ Model:Constructor (3.2675ms)
✔ Model:Mapped (4.914458ms)
✔ ModelToValibot:String (49.1405ms)
✔ ModelToValibot:Transform String to Number (5.179917ms)
✔ ModelToValibot:Transform String to Boolean (2.444459ms)
✔ ModelToValibot:Transform Object to Array (2.8625ms)
✔ ModelToValibot:Transform Object (5.827334ms)
▶ ts2typebox - Typescript to Typebox
  ✔ string (15.908625ms)
  ✔ number (2.746333ms)
  ✔ boolean (2.965917ms)
  ✔ any (1.930583ms)
  ✔ unknown (2.59175ms)
  ✔ never (1.973834ms)
  ✔ null (4.974083ms)
  ✔ Array<string> (2.455708ms)
  ✔ string[] (2.368542ms)
  ✔ Union (3.799083ms)
  ✔ Intersect (3.827916ms)
  ✔ Literal (2.4135ms)
  ✔ Object (2.196791ms)
  ✔ Tuple (1.819208ms)
  ✔ Enum (3.572625ms)
  ✔ keyof (2.035459ms)
  ✔ Record (3.181ms)
  ✔ Utility - Partial (2.232167ms)
  ✔ Utility - Pick (2.219834ms)
  ✔ Utility - Omit (2.170125ms)
  ✔ Utility - Required (2.153917ms)
  ✔ Indexed Access (2.007584ms)
  ▶ jsdoc to JSON schema options
    ✔ flat type - number (3.339125ms)
    ✔ type with properties - number (2.410208ms)
    ✔ type with properties - string (3.340541ms)
    ✔ supports ' as well as " for string JSON schema options (2.009792ms)
    ✔ type - optional (2.066291ms)
    ✔ type - number[] (2.327333ms)
    ✔ type - readonly number[] (2.302334ms)
    ✔ type - number | string (2.358459ms)
    ✔ interface (2.395542ms)
  ✔ jsdoc to JSON schema options (22.70925ms)
✔ ts2typebox - Typescript to Typebox (94.658292ms)
ℹ tests 68
ℹ suites 2
ℹ pass 68
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 477.069792
Done: 832ms
okabe@OBook-Pro typebox-codegen % 
```